### PR TITLE
Update curl and enable HTTP2 support

### DIFF
--- a/_scripts/make_static_libs.sh
+++ b/_scripts/make_static_libs.sh
@@ -5,7 +5,7 @@ source $(dirname $0)/make_static_libs_common.sh
 
 # zlib
 if [[ $ARCHINPUT = "generic" || $ARCHINPUT = "nehalem" ]]; then
-    WGET https://www.zlib.net/zlib-1.2.11.tar.gz
+    WGET https://www.zlib.net/zlib-1.2.12.tar.gz
     CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --static --prefix ${WORKDIR}
 else
     # high perf zlib version

--- a/_scripts/make_static_libs.sh
+++ b/_scripts/make_static_libs.sh
@@ -157,8 +157,7 @@ build/cmake
 ${MAKE} GLEW_PREFIX=${WORKDIR} GLEW_DEST=${WORKDIR} LIBDIR=${LIBDIR} install
 
 # openssl
-#WGET https://www.openssl.org/source/openssl-1.1.1h.tar.gz
-WGET https://github.com/openssl/openssl/archive/OpenSSL_1_1_1i.tar.gz
+WGET https://www.openssl.org/source/openssl-1.1.1o.tar.gz
 CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./config no-ssl3 no-comp no-shared no-dso no-weak-ssl-ciphers no-tests no-deprecated --prefix=${WORKDIR}
 
 ${MAKE}

--- a/_scripts/make_static_libs.sh
+++ b/_scripts/make_static_libs.sh
@@ -163,10 +163,21 @@ CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./config no-ssl3 no-comp no-shared no-dso no
 ${MAKE}
 ${MAKE} install_sw
 
+# nghttp2
+WGET https://github.com/nghttp2/nghttp2/releases/download/v1.47.0/nghttp2-1.47.0.tar.gz
+CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --enable-lib-only --prefix ${WORKDIR}
+
+${MAKE}
+${MAKE} install
+
 # curl
-#WGET https://curl.haxx.se/download/curl-7.65.3.tar.gz
-WGET https://curl.se/download/curl-7.73.0.tar.gz
-CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --disable-shared --disable-manual --disable-dict --disable-file --disable-ftp --disable-ftps --disable-gopher --disable-imap --disable-imaps --disable-pop3 --disable-pop3s --disable-rtsp --disable-smb --disable-smbs --disable-smtp --disable-smtps --disable-telnet --disable-tftp --disable-unix-sockets --with-ssl=${WORKDIR} --prefix ${WORKDIR}
+WGET https://curl.se/download/curl-7.83.1.tar.gz
+CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --disable-shared --disable-manual \
+  --disable-dict --disable-file --disable-ftp --disable-ftps --disable-gopher \
+  --disable-imap --disable-imaps --disable-pop3 --disable-pop3s --disable-rtsp \
+  --disable-smb --disable-smbs --disable-smtp --disable-smtps --disable-telnet \
+  --disable-tftp --disable-unix-sockets --with-nghttp2=${WORKDIR} \
+  --with-zlib=${WORKDIR} --with-ssl=${WORKDIR} --prefix ${WORKDIR}
 
 ${MAKE}
 ${MAKE} install


### PR DESCRIPTION
This updates curl and adds a new dependency to it: nghttp2 library needed for HTTP2 support.

HTTP2 is needed so that https://github.com/beyond-all-reason/pr-downloader/pull/9 perform well.

After this change, pr-downloader will fail to compile using docker build without merging also https://github.com/beyond-all-reason/spring/pull/303