### PR TITLE
Add upstream sources caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,24 @@ jobs:
   download:
     name: download sources
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - name: Download sources
         run: bash _scripts/download_sources.sh sources
+      - name: Authenticate to GCS
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/905252765012/locations/global/workloadIdentityPools/github-actions/providers/github
+      - name: Setup gcloud
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: google-github-actions/setup-gcloud@v3
+      - name: Sync sources to GCS cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: gcloud storage rsync sources/ gs://recoil-linux-static-build-sources-17834/
       - uses: actions/upload-artifact@v7
         with:
           name: sources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: google-github-actions/auth@v2
         with:
+          project_id: bar-data-420618
           workload_identity_provider: projects/905252765012/locations/global/workloadIdentityPools/github-actions/providers/github
       - name: Setup gcloud
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,21 @@ on:
     branches:
       - master
 jobs:
+  download:
+    name: download sources
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download sources
+        run: bash _scripts/download_sources.sh sources
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sources
+          path: sources
+          retention-days: 1
   build:
     name: build ubuntu-${{ matrix.ubuntu_version }}${{ matrix.arch_suffix }}
+    needs: download
     runs-on: ubuntu-24.04${{ matrix.arch_suffix }}
     strategy:
       fail-fast: true
@@ -24,19 +37,24 @@ jobs:
         ubuntu_version: ["20.04", "18.04"]
         arch_suffix: ["", "-arm"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          name: sources
+          path: sources
       - name: Create builder
         run: docker build --build-arg UBUNTU_VERSION=${{ matrix.ubuntu_version }} -f _scripts/Dockerfile -t builder .
       - name: Compile libraries
         run: |
-          mkdir build
+          mkdir -p build/download
+          cp sources/* build/download/
           docker run -i --rm \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/group:/etc/group:ro \
             --user="$(id -u):$(id -g)" \
             -v $(pwd)/build:/build:rw \
             builder /scripts/make_static_libs.sh /build "${{ github.event.inputs.archtune-flags }}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-${{ matrix.ubuntu_version }}${{ matrix.arch_suffix }}
           path: build
@@ -54,16 +72,16 @@ jobs:
         arch_suffix: ["", "-arm"]
     steps:
       - name: Checkout target branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ matrix.ubuntu_version }}${{ matrix.arch_suffix }}
       - name: Clean up old versions
         run: rm -rf ./*
       - name: Fetch new build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: build-${{ matrix.ubuntu_version }}${{ matrix.arch_suffix }}
       - name: Commit and push
-        uses: stefanzweifel/git-auto-commit-action@v6
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9  # v7.1.0
         with:
           commit_message: Automatic build from ${{ github.sha }}

--- a/_scripts/download_sources.sh
+++ b/_scripts/download_sources.sh
@@ -10,15 +10,25 @@ fi
 DLDIR=$1
 mkdir -p "${DLDIR}"
 
+GCS_CACHE_BASE=https://storage.googleapis.com/recoil-linux-static-build-sources-17834
+
 function DOWNLOAD {
 	local URL=$1
 	local SHA256=$2
 	local NAME=${3:-$(basename "$URL")}
 	local FILENAME=${DLDIR}/${NAME}
-	if ! [ -s "$FILENAME" ]; then
-		echo "Downloading ${NAME}..."
-		wget -q "$URL" -O "$FILENAME"
+	if [ -s "$FILENAME" ] && echo "$SHA256  $FILENAME" | sha256sum --check 2>/dev/null; then
+		return
 	fi
+	rm -f "$FILENAME"
+	echo "Trying cache for ${NAME}..."
+	if wget -q "${GCS_CACHE_BASE}/${NAME}" -O "$FILENAME" 2>/dev/null \
+	   && echo "$SHA256  $FILENAME" | sha256sum --check 2>/dev/null; then
+		return
+	fi
+	rm -f "$FILENAME"
+	echo "Downloading ${NAME} from origin..."
+	wget -q "$URL" -O "$FILENAME"
 	echo "$SHA256  $FILENAME" | sha256sum --check
 }
 

--- a/_scripts/download_sources.sh
+++ b/_scripts/download_sources.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -eq 0 ]; then
+	echo "Usage: $0 <destination-directory>"
+	exit 2
+fi
+
+DLDIR=$1
+mkdir -p "${DLDIR}"
+
+function DOWNLOAD {
+	local URL=$1
+	local SHA256=$2
+	local NAME=${3:-$(basename "$URL")}
+	local FILENAME=${DLDIR}/${NAME}
+	if ! [ -s "$FILENAME" ]; then
+		echo "Downloading ${NAME}..."
+		wget -q "$URL" -O "$FILENAME"
+	fi
+	echo "$SHA256  $FILENAME" | sha256sum --check
+}
+
+# zlib (used for generic/nehalem builds)
+DOWNLOAD https://zlib.net/fossils/zlib-1.3.1.tar.gz \
+         9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+
+# zlib-ng (used for non-generic builds)
+DOWNLOAD https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.1.5.tar.gz \
+         3f6576971397b379d4205ae5451ff5a68edf6c103b2f03c4188ed7075fbb5f04 \
+         zlib-ng-2.1.5.tar.gz
+
+# libpng
+DOWNLOAD https://downloads.sourceforge.net/project/libpng/libpng16/1.6.50/libpng-1.6.50.tar.gz \
+         708f4398f996325819936d447f982e0db90b6b8212b7507e7672ea232210949a
+
+# libgif
+DOWNLOAD https://downloads.sourceforge.net/project/giflib/giflib-5.x/giflib-5.2.2.tar.gz \
+         be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb
+
+# libjpeg
+DOWNLOAD https://www.ijg.org/files/jpegsrc.v9f.tar.gz \
+         04705c110cb2469caa79fb71fba3d7bf834914706e9641a4589485c1f832565b
+
+# libtiff
+DOWNLOAD https://download.osgeo.org/libtiff/tiff-4.7.0.tar.gz \
+         67160e3457365ab96c5b3286a0903aa6e78bdc44c4bc737d2e486bcecb6ba976
+
+# DevIL
+DOWNLOAD https://downloads.sourceforge.net/project/openil/DevIL/1.8.0/DevIL-1.8.0.tar.gz \
+         0075973ee7dd89f0507873e2580ac78336452d29d34a07134b208f44e2feb709
+
+# libunwind
+DOWNLOAD https://download.savannah.nongnu.org/releases/libunwind/libunwind-1.6.2.tar.gz \
+         4a6aec666991fb45d0889c44aede8ad6eb108071c3554fcdff671f9c94794976
+
+# GLEW
+DOWNLOAD https://downloads.sourceforge.net/project/glew/glew/2.2.0/glew-2.2.0.tgz \
+         d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1
+
+# OpenSSL
+DOWNLOAD https://github.com/openssl/openssl/releases/download/openssl-3.5.2/openssl-3.5.2.tar.gz \
+         c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec
+
+# nghttp2
+DOWNLOAD https://github.com/nghttp2/nghttp2/releases/download/v1.66.0/nghttp2-1.66.0.tar.gz \
+         e178687730c207f3a659730096df192b52d3752786c068b8e5ee7aeb8edae05a
+
+# libpsl
+DOWNLOAD https://github.com/rockdaboot/libpsl/releases/download/0.21.5/libpsl-0.21.5.tar.gz \
+         1dcc9ceae8b128f3c0b3f654decd0e1e891afc6ff81098f227ef260449dae208
+
+# curl
+DOWNLOAD https://curl.se/download/curl-8.15.0.tar.gz \
+         d85cfc79dc505ff800cb1d321a320183035011fa08cb301356425d86be8fc53c
+
+# libogg
+DOWNLOAD https://github.com/xiph/ogg/releases/download/v1.3.6/libogg-1.3.6.tar.gz \
+         83e6704730683d004d20e21b8f7f55dcb3383cdf84c0daedf30bde175f774638
+
+# libvorbis
+DOWNLOAD https://github.com/xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.gz \
+         0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab
+
+# libuuid
+DOWNLOAD https://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz \
+         46af3275291091009ad7f1b899de3d0cea0252737550e7919d17237997db5644
+
+# xz
+DOWNLOAD https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1.tar.gz \
+         507825b599356c10dca1cd720c9d0d0c9d5400b9de300af00e4d1ea150795543
+
+# minizip
+DOWNLOAD https://github.com/nmoinvaz/minizip/archive/refs/tags/4.0.10.tar.gz \
+         c362e35ee973fa7be58cc5e38a4a6c23cc8f7e652555daf4f115a9eb2d3a6be7 \
+         minizip-ng-4.0.10.tar.gz
+
+echo "All sources downloaded and verified."

--- a/_scripts/make_static_libs.sh
+++ b/_scripts/make_static_libs.sh
@@ -5,8 +5,7 @@ source $(dirname $0)/make_static_libs_common.sh
 
 # zlib
 if [[ $ARCHINPUT = "generic" || $ARCHINPUT = "nehalem" ]]; then
-    WGET https://zlib.net/fossils/zlib-1.3.1.tar.gz \
-         9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+    EXTRACT zlib-1.3.1.tar.gz
     CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --static --prefix ${WORKDIR}
 else
     # high perf zlib version
@@ -24,7 +23,7 @@ else
     #-DCMAKE_INSTALL_PREFIX=${WORKDIR} \
     #.
     # slighty less higher perf zlib version
-    GITCLONE https://github.com/zlib-ng/zlib-ng.git zlib 2.1.5
+    EXTRACT zlib-ng-2.1.5.tar.gz
     ${CMAKE} \
     -DCMAKE_CXX_FLAGS="${MYCFLAGS}" \
     -DCMAKE_C_FLAGS="${MYCFLAGS}" \
@@ -45,8 +44,7 @@ ${MAKECMD}
 ${MAKECMD} install
 
 # libpng
-WGET https://downloads.sourceforge.net/project/libpng/libpng16/1.6.50/libpng-1.6.50.tar.gz \
-     708f4398f996325819936d447f982e0db90b6b8212b7507e7672ea232210949a
+EXTRACT libpng-1.6.50.tar.gz
 ${CMAKE} \
 -DCMAKE_CXX_FLAGS="${MYCFLAGS}" \
 -DCMAKE_C_FLAGS="${MYCFLAGS}" \
@@ -62,23 +60,20 @@ ${MAKECMD}
 ${MAKECMD} install
 
 # libgif
-WGET https://sourceforge.net/projects/giflib/files/giflib-5.x/giflib-5.2.2.tar.gz/download \
-     be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb
+EXTRACT giflib-5.2.2.tar.gz
 sed -ie "s/OFLAGS  = -O2/OFLAGS=${MYCFLAGS}/g"  Makefile
 ${MAKECMD} libgif.a libgif.so  # so is needed only for install-lib to work
 ${MAKECMD} install-include install-lib PREFIX=${WORKDIR}
 
 # libjpeg
-WGET https://www.ijg.org/files/jpegsrc.v9f.tar.gz \
-     04705c110cb2469caa79fb71fba3d7bf834914706e9641a4589485c1f832565b
+EXTRACT jpegsrc.v9f.tar.gz
 CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --prefix ${WORKDIR}
 
 ${MAKECMD}
 ${MAKECMD} install
 
 # libtiff
-WGET https://download.osgeo.org/libtiff/tiff-4.7.0.tar.gz \
-     67160e3457365ab96c5b3286a0903aa6e78bdc44c4bc737d2e486bcecb6ba976
+EXTRACT tiff-4.7.0.tar.gz
 CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --disable-lzma --disable-jbig \
   --disable-docs --disable-tests --disable-tools --disable-contrib --prefix ${WORKDIR}
 
@@ -86,9 +81,8 @@ ${MAKECMD}
 ${MAKECMD} install
 
 # libIL (DevIL)
-#WGET https://api.github.com/repos/spring/DevIL/tarball/d46aa9989f502b89de06801925d20e53d220c1b4
-WGET https://downloads.sourceforge.net/project/openil/DevIL/1.8.0/DevIL-1.8.0.tar.gz \
-     0075973ee7dd89f0507873e2580ac78336452d29d34a07134b208f44e2feb709
+#EXTRACT DevIL tarball from api.github.com/repos/spring/DevIL/...
+EXTRACT DevIL-1.8.0.tar.gz
 cd DevIL
 cd src-IL
 ${CMAKE} \
@@ -140,16 +134,14 @@ ${MAKECMD} install
 
 
 # libunwind
-WGET https://download.savannah.nongnu.org/releases/libunwind/libunwind-1.6.2.tar.gz \
-     4a6aec666991fb45d0889c44aede8ad6eb108071c3554fcdff671f9c94794976
+EXTRACT libunwind-1.6.2.tar.gz
 CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --enable-shared=no --enable-static=yes --prefix ${WORKDIR}
 
 ${MAKECMD}
 ${MAKECMD} install
 
 # glew
-WGET https://downloads.sourceforge.net/project/glew/glew/2.2.0/glew-2.2.0.tgz \
-     d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1
+EXTRACT glew-2.2.0.tgz
 ${CMAKE} \
 -DCMAKE_CXX_FLAGS="${MYCFLAGS}" \
 -DCMAKE_C_FLAGS="${MYCFLAGS}" \
@@ -165,32 +157,27 @@ build/cmake
 ${MAKECMD} GLEW_PREFIX=${WORKDIR} GLEW_DEST=${WORKDIR} LIBDIR=${LIBDIR} install
 
 # openssl
-WGET https://github.com/openssl/openssl/releases/download/openssl-3.5.2/openssl-3.5.2.tar.gz \
-     c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec
+EXTRACT openssl-3.5.2.tar.gz
 CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./config no-ssl3 no-comp no-shared no-dso no-weak-ssl-ciphers no-tests no-deprecated --libdir=lib --prefix=${WORKDIR}
 
 ${MAKECMD}
 ${MAKECMD} install_sw
 
 # nghttp2 for curl
-WGET https://github.com/nghttp2/nghttp2/releases/download/v1.66.0/nghttp2-1.66.0.tar.gz \
-     e178687730c207f3a659730096df192b52d3752786c068b8e5ee7aeb8edae05a
+EXTRACT nghttp2-1.66.0.tar.gz
 CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --enable-lib-only --disable-shared --prefix ${WORKDIR}
 
 ${MAKECMD}
 ${MAKECMD} install
 
 # libpsl for curl
-WGET https://github.com/rockdaboot/libpsl/releases/download/0.21.5/libpsl-0.21.5.tar.gz \
-     1dcc9ceae8b128f3c0b3f654decd0e1e891afc6ff81098f227ef260449dae208
-
+EXTRACT libpsl-0.21.5.tar.gz
 CFLAGS=$MYCFLAGS ./configure --disable-shared --prefix ${WORKDIR}
 ${MAKECMD}
 ${MAKECMD} install
 
 # curl
-WGET https://curl.se/download/curl-8.15.0.tar.gz \
-     d85cfc79dc505ff800cb1d321a320183035011fa08cb301356425d86be8fc53c
+EXTRACT curl-8.15.0.tar.gz
 CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --disable-shared --disable-manual \
   --disable-dict --disable-file --disable-ftp --disable-gopher --disable-imap \
   --disable-pop3 --disable-rtsp --disable-smb --disable-smtp --disable-smtps \
@@ -203,8 +190,7 @@ ${MAKECMD}
 ${MAKECMD} install
 
 # libogg-dev
-WGET https://github.com/xiph/ogg/releases/download/v1.3.6/libogg-1.3.6.tar.gz \
-     83e6704730683d004d20e21b8f7f55dcb3383cdf84c0daedf30bde175f774638
+EXTRACT libogg-1.3.6.tar.gz
 CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --prefix ${WORKDIR} \
 --enable-shared=no \
 --enable-static=yes
@@ -213,8 +199,7 @@ ${MAKECMD}
 ${MAKECMD} install
 
 #libvorbis
-WGET https://github.com/xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.gz \
-     0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab
+EXTRACT libvorbis-1.3.7.tar.gz
 CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --prefix ${WORKDIR} \
 --enable-shared=no \
 --enable-static=yes \
@@ -224,8 +209,7 @@ ${MAKECMD}
 ${MAKECMD} install
 
 #libuuid
-WGET https://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz \
-     46af3275291091009ad7f1b899de3d0cea0252737550e7919d17237997db5644
+EXTRACT libuuid-1.0.3.tar.gz
 CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --prefix ${WORKDIR} \
 --enable-shared=no \
 --enable-static=yes \
@@ -234,8 +218,7 @@ CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --prefix ${WORKDIR} \
 ${MAKECMD}
 ${MAKECMD} install
 
-WGET https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1.tar.gz \
-     507825b599356c10dca1cd720c9d0d0c9d5400b9de300af00e4d1ea150795543
+EXTRACT xz-5.8.1.tar.gz
 CFLAGS=$MYCFLAGS CXXFLAGS=$MYCFLAGS ./configure --prefix ${WORKDIR} \
 --enable-shared=no \
 --enable-static=yes \
@@ -248,8 +231,7 @@ ${MAKECMD}
 ${MAKECMD} install
 
 #high perf version
-GITCLONE https://github.com/nmoinvaz/minizip.git minizip 4.0.10 \
-         f3ed731e27a97e30dffe076ed5e0537daae5c1bd
+EXTRACT minizip-ng-4.0.10.tar.gz
 ${CMAKE} \
 -DCMAKE_CXX_FLAGS="${MYCFLAGS}" \
 -DCMAKE_C_FLAGS="${MYCFLAGS}" \

--- a/_scripts/make_static_libs_common.sh
+++ b/_scripts/make_static_libs_common.sh
@@ -53,36 +53,17 @@ mkdir -p ${INCLUDEDIR}
 mkdir -p ${LIBDIR}
 mkdir -p ${DLDIR}
 
-function WGET {
-  local URL=$1
-  local SHA256=$2
-  local FILENAME=${DLDIR}/$(basename $1)
-  if ! [ -s $FILENAME ]; then
-    /usr/bin/wget $1 -O $FILENAME
+function EXTRACT {
+  local FILENAME=${DLDIR}/$1
+  if ! [ -s "$FILENAME" ]; then
+    echo "Missing pre-downloaded archive: $1"
+    exit 1
   fi
-  sha256sum $FILENAME
-  echo "$SHA256 $FILENAME" | sha256sum --check
+  local HASH
+  HASH=$(sha256sum "$FILENAME" | cut -d' ' -f1)
 
-  mkdir $TMPDIR/$SHA256
-  cd $TMPDIR/$SHA256
+  mkdir $TMPDIR/$HASH
+  cd $TMPDIR/$HASH
   export SOURCE_DATE_EPOCH=$(date -d "$(tar -tzvf $FILENAME --full-time | awk '{print $4, $5}' | sort | tail -n 1)" +%s)
   tar xifzv $FILENAME --strip-components=1
-}
-
-function GITCLONE {
-  local URL=$1
-  local DIR=$2
-  local BRANCH=$3
-  local COMMIT=$4
-
-  mkdir $TMPDIR/$COMMIT
-  cd $TMPDIR/$COMMIT
-
-  git clone --recursive -b $BRANCH $URL $DIR
-  cd $DIR
-  git rev-parse HEAD
-  if [[ $(git rev-parse HEAD) != $COMMIT ]]; then
-    echo "Fetched and expected git commit don't match"
-  fi
-  export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 }


### PR DESCRIPTION
- Depend only on wget, not git clone
- Download sources only once, not in every separate subaction by refactoring the downloading into separate step
- Add persistent sources cache to GCS bucket to protect against deletions from upstream and unstable URLs: sha256 checksums still guarantee security

Resolves #9